### PR TITLE
Add static isConnectorAvailable methods to Connector sub-classes

### DIFF
--- a/src/main/java/com/jcraft/jsch/agentproxy/connector/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/agentproxy/connector/PageantConnector.java
@@ -70,8 +70,12 @@ public class PageantConnector implements Connector {
     return "pageant";
   }
 
-  public boolean isAvailable(){
+  public static boolean isConnectorAvailable(){
     return System.getProperty("os.name").startsWith("Windows");
+  }
+
+  public boolean isAvailable(){
+    return isConnectorAvailable();
   }
 
   public interface User32 extends  com.sun.jna.platform.win32.User32 {

--- a/src/main/java/com/jcraft/jsch/agentproxy/connector/SSHAgentConnector.java
+++ b/src/main/java/com/jcraft/jsch/agentproxy/connector/SSHAgentConnector.java
@@ -64,8 +64,12 @@ public class SSHAgentConnector implements Connector {
     return "ssh-agent";
   }
 
-  public boolean isAvailable(){
+  public static boolean isConnectorAvailable(){
     return System.getenv("SSH_AUTH_SOCK")!=null;
+  }
+
+  public boolean isAvailable(){
+    return isConnectorAvailable();
   }
 
   private USocketFactory.Socket open() throws IOException {


### PR DESCRIPTION
The isAvailable method is only useable after creating a connector. Adding static methods
allows querying a connector to see if it is available before instantiating it.
