### PR TITLE
Provide a simple interface for trying to get a connector

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,6 +16,11 @@
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.simple</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.jsch</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/examples/src/main/java/com/jcraft/agentproxy/examples/JSchWithAgentProxy.java
+++ b/examples/src/main/java/com/jcraft/agentproxy/examples/JSchWithAgentProxy.java
@@ -2,10 +2,15 @@
 package com.jcraft.jsch.agentproxy.examples;
 
 import com.jcraft.jsch.*;
-import com.jcraft.jsch.agentproxy.*;
-import com.jcraft.jsch.agentproxy.usocket.*;
-import com.jcraft.jsch.agentproxy.connector.*;
-import java.io.*;
+import com.jcraft.jsch.agentproxy.AgentProxyException;
+import com.jcraft.jsch.agentproxy.Connector;
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
+import com.jcraft.jsch.agentproxy.USocketFactory;
+import com.jcraft.jsch.agentproxy.connector.PageantConnector;
+import com.jcraft.jsch.agentproxy.connector.SSHAgentConnector;
+import com.jcraft.jsch.agentproxy.simple.ConnectorFactory;
+import com.jcraft.jsch.agentproxy.usocket.JNAUSocketFactory;
+
 import javax.swing.*; 
 
 public class JSchWithAgentProxy {
@@ -18,6 +23,7 @@ public class JSchWithAgentProxy {
 
       Connector con = null;
 
+      /* The manual way to get a connector: */
       try {
         if(SSHAgentConnector.isConnectorAvailable()){
           //USocketFactory usf = new JUnixDomainSocketFactory();
@@ -37,6 +43,10 @@ public class JSchWithAgentProxy {
         System.out.println(e);
       }
 
+      /* ...or, the one-size-fits-all (reduced control) way: */
+      con = ConnectorFactory.getConnector();
+
+      /* Usage is the same in either event */
       if(con != null ){
         IdentityRepository irepo = new RemoteIdentityRepository(con);
         jsch.setIdentityRepository(irepo);

--- a/jsch-agent-proxy-simple/pom.xml
+++ b/jsch-agent-proxy-simple/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.jcraft</groupId>
+    <artifactId>jsch.agentproxy</artifactId>
+    <version>0.0.6</version>
+  </parent>
+
+  <artifactId>jsch.agentproxy.simple</artifactId>
+  <name>a simple agent connector factory</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.usocket-jna</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.sshagent</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.pageant</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.2</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jsch-agent-proxy-simple/pom.xml
+++ b/jsch-agent-proxy-simple/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.usocket-nc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.sshagent</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/jsch-agent-proxy-simple/src/com/jcraft/jsch/agentproxy/simple/ConnectorFactory.java
+++ b/jsch-agent-proxy-simple/src/com/jcraft/jsch/agentproxy/simple/ConnectorFactory.java
@@ -1,0 +1,35 @@
+package com.jcraft.jsch.agentproxy.simple;
+
+import com.jcraft.jsch.agentproxy.AgentProxyException;
+import com.jcraft.jsch.agentproxy.Connector;
+import com.jcraft.jsch.agentproxy.USocketFactory;
+import com.jcraft.jsch.agentproxy.connector.PageantConnector;
+import com.jcraft.jsch.agentproxy.connector.SSHAgentConnector;
+import com.jcraft.jsch.agentproxy.usocket.JNAUSocketFactory;
+
+public class ConnectorFactory {
+    /** Try the currently recommended methods to retrieve an agent connector.
+     *
+     * Use the most widely-supported / recommended / maintained mechanisms to
+     * attempt to connect to a local SSH agent. This exists for ease-of-use;
+     * developers seeking more fine-grained control (to reduce platform
+     * dependencies, to use less-common connectors, to modify the search
+     * order, etc) should leverage the desired connectors directly.
+     *
+     * @return A usable SSH agent connector, or null if none is available.
+     */
+    public static Connector getConnector() {
+        try {
+            Connector con = null;
+            if(SSHAgentConnector.isConnectorAvailable()) {
+                USocketFactory usf = new JNAUSocketFactory();
+                con = new SSHAgentConnector(usf);
+            } else if(PageantConnector.isConnectorAvailable()) {
+                con = new PageantConnector();
+            }
+            return con;
+        } catch(AgentProxyException e) {
+            return null;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
   <modules>
     <module>jsch-agent-proxy-core</module>
+    <module>jsch-agent-proxy-simple</module>
     <module>jsch-agent-proxy-jsch</module>
     <module>jsch-agent-proxy-sshj</module>
     <module>jsch-agent-proxy-pageant</module>


### PR DESCRIPTION
At present, it is the responsible of the jsch-agent-proxy user to know which connectors should be attempted and in which order. While there are legitimate reasons for a user to want fine-grained control over this (attempting to minimize dependencies; only targeting a subset of the platforms jsch-agent-proxy supports; etc), there is currently no common-case way for a user to simply "make it work" without boilerplate (which may need to change with future library releases should an existing connector be deprecated, a new one being added, etc).

This patch introduces jsch.agentproxy.simple, which provides a single entry point for the connectors which are currently suggested for use. If it does not currently reflect best-practice selection, or if best-practices change in the future, it provides a single place where this can be updated, rather than needing to explicitly modify clients which may not necessarily need the more fine-grained control possible by directly depending on and using the individual connector subprojects.
