### PR TITLE
Do not hardcode sockaddr.size(); make JNA error messages more useful

### DIFF
--- a/jsch-agent-proxy-usocket-jna/src/main/java/com/jcraft/jsch/agentproxy/usocket/JNAUSocketFactory.java
+++ b/jsch-agent-proxy-usocket-jna/src/main/java/com/jcraft/jsch/agentproxy/usocket/JNAUSocketFactory.java
@@ -112,9 +112,10 @@ public class JNAUSocketFactory implements USocketFactory {
       throw new IOException("failed to allocate usocket");
     }
 
-    if(CLibrary.INSTANCE.fcntl(sock,  2, 8) < 0){
+    int retval = CLibrary.INSTANCE.fcntl(sock,  2, 8);
+    if(retval < 0){
       CLibrary.INSTANCE.close(sock);
-      throw new IOException("failed to fctrl usocket");
+      throw new IOException("failed to fctrl usocket: " + retval);
     }
 
     SockAddr sockaddr = new SockAddr();
@@ -125,8 +126,9 @@ public class JNAUSocketFactory implements USocketFactory {
                      path.length());
     sockaddr.write();
 
-    if(CLibrary.INSTANCE.connect(sock, sockaddr.getPointer(), 110)<0){
-      throw new IOException("failed to fctrl usocket");
+    retval = CLibrary.INSTANCE.connect(sock, sockaddr.getPointer(), sockaddr.size());
+    if(retval < 0) {
+      throw new IOException("failed to connect usocket: " + retval);
     }
 
     return new MySocket(sock);


### PR DESCRIPTION
Not all platforms (or even all versions of Linux) have the same definition of `sockaddr_t`.

Use `Structure.size()` to get the correct value.
