### PR TITLE
getFieldOrder() method has beend added to com.sun.jna.Structure

### DIFF
--- a/jsch-agent-proxy-pageant/src/main/java/com/jcraft/jsch/agentproxy/connector/PageantConnector.java
+++ b/jsch-agent-proxy-pageant/src/main/java/com/jcraft/jsch/agentproxy/connector/PageantConnector.java
@@ -29,6 +29,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.jcraft.jsch.agentproxy.connector;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.jcraft.jsch.agentproxy.Connector;
 import com.jcraft.jsch.agentproxy.AgentProxyException;
 import com.jcraft.jsch.agentproxy.Buffer;
@@ -90,12 +93,22 @@ public class PageantConnector implements Connector {
     public int dwData;
     public int cbData;
     public Pointer lpData;
+
+    @Override
+    protected List<String> getFieldOrder() {
+        return Arrays.asList(new String[] {"dwData", "cbData", "lpData"});
+    }
   }
 
   public class COPYDATASTRUCT64 extends Structure {
     public int dwData;
     public long cbData;
     public Pointer lpData;
+
+    @Override
+    protected List<String> getFieldOrder() {
+        return Arrays.asList(new String[] {"dwData", "cbData", "lpData"});
+    }
   }
 
   public void query(Buffer buffer) throws AgentProxyException {

--- a/jsch-agent-proxy-usocket-jna/src/main/java/com/jcraft/jsch/agentproxy/usocket/JNAUSocketFactory.java
+++ b/jsch-agent-proxy-usocket-jna/src/main/java/com/jcraft/jsch/agentproxy/usocket/JNAUSocketFactory.java
@@ -38,6 +38,8 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class JNAUSocketFactory implements USocketFactory {
 
@@ -54,6 +56,11 @@ public class JNAUSocketFactory implements USocketFactory {
   public static class SockAddr extends Structure {
     public short sun_family;
     public byte[] sun_path;
+
+    @Override
+    protected List<String> getFieldOrder() {
+        return Arrays.asList(new String[] {"sun_family", "sun_path"});
+    }
   }
 
   public JNAUSocketFactory() throws AgentProxyException {


### PR DESCRIPTION
subclasses in order to make code compatible with JNA 3.5 and newer
versions where Structure introduces abstract getFieldOrder() method.
