### PR TITLE
Upgrading jna from 3.4.0 to 4.1.0

### DIFF
--- a/README
+++ b/README
@@ -63,7 +63,7 @@ Dependencies
 ============
 To work as a proxy to ssh-agent and Pageant,
 the current implementation depends on the following software
-  * JNA: https://github.com/twall/jna licensed under the GNU LGPL
+  * JNA: https://github.com/twall/jna licensed under the GNU LGPL and the Apache License 2.0
   * junixsocket: http://code.google.com/p/junixsocket/ licensed under the Apache License 2.0
   * OpenBSD's netcat: http://www.openbsd.org/cgi-bin/cvsweb/src/usr.bin/nc/
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This software is licensed under [BSD style license](https://github.com/ymnk/jsch
 To work as a proxy to ssh-agent and Pageant,
 the current implementation depends on the following software,
  
-+ JNA: https://github.com/twall/jna licensed under the [GNU LGPL](https://github.com/twall/jna/blob/master/LICENSE)
++ JNA: https://github.com/twall/jna licensed under the [GNU LGPL](https://github.com/twall/jna/blob/master/LICENSE) and the [Apache License 2.0](http://code.google.com/p/junixsocket/source/browse/trunk/junixsocket/LICENSE.txt)
 + junixsocket: http://code.google.com/p/junixsocket/ licensed under the [Apache License 2.0](http://code.google.com/p/junixsocket/source/browse/trunk/junixsocket/LICENSE.txt)
 + OpenBSD's netcat: http://www.openbsd.org/cgi-bin/cvsweb/src/usr.bin/nc/
 

--- a/jsch-agent-proxy-pageant/pom.xml
+++ b/jsch-agent-proxy-pageant/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
-      <artifactId>platform</artifactId>
+      <artifactId>jna-platform</artifactId>
       <version>${jna.version}</version>
     </dependency>
   </dependencies>

--- a/jsch-agent-proxy-usocket-jna/pom.xml
+++ b/jsch-agent-proxy-usocket-jna/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
-      <artifactId>platform</artifactId>
+      <artifactId>jna-platform</artifactId>
       <version>${jna.version}</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jsch.version>0.1.49</jsch.version>
-    <jna.version>3.4.0</jna.version>
+    <jna.version>4.1.0</jna.version>
     <trilead.version>1.0.0-build217</trilead.version>
   </properties>
 


### PR DESCRIPTION
4.1.0 is dual-licensed under LGPL and ASL 2

Motivation for this comes from http://apache.markmail.org/thread/qqzou2moxj5n5ibv and https://issues.apache.org/jira/browse/JCLOUDS-721
