### PR TITLE
Excluding com.jcraft.jsch.agentproxy from exported packages

### DIFF
--- a/jsch-agent-proxy-connector-factory/pom.xml
+++ b/jsch-agent-proxy-connector-factory/pom.xml
@@ -48,6 +48,18 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.3.2</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <!-- ensure jsch.agentproxy.core files aren't packaged -->
+          <excludeDependencies>true</excludeDependencies>
+          <instructions>
+            <!-- provided by jsch.agentproxy.core -->
+            <Export-Package>!com.jcraft.jsch.agentproxy</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Also ensuring it's no longer transitively included in the JAR.
This means OSGi users will also need to import the
jsch.agentproxy.core bundle, which _should_ be providing the core
files.

That, in turn, avoids a "uses constraint violation" when trying to
load both the usocket-nc and usocket-jna bundles if the core bundle
is not being imported (which is currently not necessary, since
connector-factory exports the core package too).
