### PR TITLE
Update SSHJ version and Maven coordinates

### DIFF
--- a/jsch-agent-proxy-sshj/pom.xml
+++ b/jsch-agent-proxy-sshj/pom.xml
@@ -14,9 +14,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>net.schmizz</groupId>
+      <groupId>com.hierynomus</groupId>
       <artifactId>sshj</artifactId>
-      <version>[0.8.1,)</version>
+      <version>0.12.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>


### PR DESCRIPTION
SSHJ is under new management at https://github.com/hierynomus/sshj
